### PR TITLE
Add support for Ciseco SRF-Stick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ASM_REL = $(ASM_SRC:.asm=.rel)
 ASM_RST = $(ASM_SRC:.asm=.rst)
 ASM_SYM = $(ASM_SRC:.asm=.sym)
 
-PROGS = CCBootloader.hex CCBootloader-rfcat-chronosdongle.hex CCBootloader-rfcat-donsdongle.hex CCBootloader-rfcat-ys1.hex
+PROGS = CCBootloader.hex CCBootloader-rfcat-chronosdongle.hex CCBootloader-rfcat-donsdongle.hex CCBootloader-rfcat-ys1.hex CCBootloader-rfcat-srf.hex
 PCDB = $(PROGS:.hex=.cdb)
 PLNK = $(PROGS:.hex=.lnk)
 PMAP = $(PROGS:.hex=.map)
@@ -75,6 +75,10 @@ CCBootloader-rfcat-ys1.hex: CFLAGS += -DRFCAT -DRFCAT_YARDSTICKONE
 CCBootloader-rfcat-ys1.hex: $(REL) $(ASM_REL) Makefile
 	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader-rfcat-ys1.hex $(ASM_REL) $(REL)
 
+CCBootloader-rfcat-srf.hex: CFLAGS += -DRFCAT -DRFCAT_SRFSTICK
+CCBootloader-rfcat-srf.hex: $(REL) $(ASM_REL) Makefile
+	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader-rfcat-srf.hex $(ASM_REL) $(REL)
+
 clean:
 	rm -f $(ADB) $(ASM) $(LNK) $(LST) $(REL) $(RST) $(SYM)
 	rm -f $(ASM_ADB) $(ASM_LNK) $(ASM_LST) $(ASM_REL) $(ASM_RST) $(ASM_SYM)
@@ -100,3 +104,7 @@ installys1dongle: CCBootloader-rfcat-ys1.hex
 	goodfet.cc flash CCBootloader-rfcat-ys1.hex
 	goodfet.cc verify CCBootloader-rfcat-ys1.hex
 
+installsrfdongle: CCBootloader-rfcat-srf.hex
+	goodfet.cc erase
+	goodfet.cc flash CCBootloader-rfcat-srf.hex
+	goodfet.cc verify CCBootloader-rfcat-srf.hex

--- a/src/hal.c
+++ b/src/hal.c
@@ -54,7 +54,7 @@ void setup_gpio() {
 }
 
 void led_on() {
-#ifdef RFCAT_YARDSTICKONE
+#if defined(RFCAT_YARDSTICKONE) || defined(RFCAT_SRFSTICK)
   LED1 = 1;
   LED2 = 1;
   LED3 = 1;
@@ -64,7 +64,7 @@ void led_on() {
 }
 
 void led_off() {
-#ifdef RFCAT_YARDSTICKONE
+#if defined(RFCAT_YARDSTICKONE) || defined(RFCAT_SRFSTICK)
   LED1 = 0;
   LED2 = 0;
   LED3 = 0;
@@ -75,12 +75,20 @@ void led_off() {
 
 void usb_up() {
   // Bring up the USB link
+#ifdef RFCAT_SRFSTICK
+  P2DIR |= USB_MASK;
+#else
   P1DIR |= USB_MASK;
+#endif
   USB_ENABLE = 1;
 }
 
 void usb_down() {
   // Bring down the USB link
   USB_ENABLE = 0;
+#ifdef RFCAT_SRFSTICK
+  P2DIR &= ~USB_MASK;
+#else
   P1DIR &= ~USB_MASK;
+#endif
 }

--- a/src/hal.h
+++ b/src/hal.h
@@ -49,6 +49,15 @@
   #define AMP_BYPASS_EN		P2_3
 #endif
 
+#ifdef RFCAT_SRFSTICK
+  #define LED1 			P1_5
+  #define LED2 			P1_6
+  #define LED3 			P1_7
+  #define LED_MASK		((1<<7)|(1<<6)|(1<<5))
+  #define USB_ENABLE		P2_0
+  #define USB_MASK		0x01
+#endif
+
 void setup_led();
 void led_on();
 void led_off();

--- a/src/usb.h
+++ b/src/usb.h
@@ -153,6 +153,17 @@ struct usb_line_coding {
   #define USB_iProduct_LEN 0x34
   #define USB_iProduct_STRING "YARD Stick One Bootloader"
   #define USB_iProduct_UCS2 'Y', 0, 'A', 0, 'R', 0, 'D', 0, ' ', 0, 'S', 0, 't', 0, 'i', 0, 'c', 0, 'k', 0, ' ', 0, 'O', 0, 'n', 0, 'e', 0, ' ', 0, 'B', 0, 'o', 0, 'o', 0, 't', 0, 'l', 0, 'o', 0, 'a', 0, 'd', 0, 'e', 0, 'r', 0
+#elif defined RFCAT_SRFSTICK
+  #define USB_VID 0x1D50
+  #define USB_PID 0xECC0
+  // iManufacturer
+  #define USB_iManufacturer_LEN 0x0C
+  #define USB_iManufacturer_STRING "RfCat"
+  #define USB_iManufacturer_UCS2 'R', 0, 'f', 0, 'C', 0, 'a', 0, 't', 0
+  // iProduct
+  #define USB_iProduct_LEN 0x2A
+  #define USB_iProduct_STRING "SRF-Stick Bootloader"
+  #define USB_iProduct_UCS2 'S', 0, 'R', 0, 'F', 0, '-', 0, 'S', 0, 't', 0, 'i', 0, 'c', 0, 'k', 0, ' ', 0, 'B', 0, 'o', 0, 'o', 0, 't', 0, 'l', 0, 'o', 0, 'a', 0, 'd', 0, 'e', 0, 'r', 0
 #else
   #define USB_VID 0xFFFE
   #define USB_PID 0x000A


### PR DESCRIPTION
I added support for another CC1111 dongle from Ciseco (now Wireless Things): https://www.wirelessthings.net/srf-stick-868-915-mhz-easy-to-use-usb-radio

But it's only marginally useful because this dongle does not have a pushbutton to force it into bootloader mode.

Also, I made up USB product IDs (ecc0 and ecc1 :-) without requesting them through OpenMoko, mea culpa.
