### PR TITLE
sdcc + clean make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ ifdef DEBUG
 CFLAGS += --debug
 endif
 
+CHRONOS_FLAGS = -DRFCAT_CHRONOS
+DONS_FLAGS = -DRFCAT_DONSDONGLE
+YS1_FLAGS = -DRFCAT_YARDSTICKONE
+
 SRC = \
 	src/main.c \
 	src/usb.c \
@@ -30,13 +34,9 @@ SRC = \
 
 ASM_SRC = src/start.asm
 
-ADB = $(SRC:.c=.c.adb)
-ASM = $(SRC:.c=.c.asm)
-LNK = $(SRC:.c=.c.lnk)
-LST = $(SRC:.c=.c.lst)
-REL = $(SRC:.c=.c.rel)
-RST = $(SRC:.c=.c.rst)
-SYM = $(SRC:.c=.c.sym)
+CHRONOS_REL = $(SRC:.c=.c.chronos.rel)
+DONS_REL = $(SRC:.c=.c.dons.rel)
+YS1_REL = $(SRC:.c=.c.ys1.rel)
 
 ASM_ADB = $(ASM_SRC:.asm=.adb)
 ASM_LNK = $(ASM_SRC:.asm=.lnk)
@@ -45,45 +45,41 @@ ASM_REL = $(ASM_SRC:.asm=.rel)
 ASM_RST = $(ASM_SRC:.asm=.rst)
 ASM_SYM = $(ASM_SRC:.asm=.sym)
 
-PROGS = CCBootloader.hex CCBootloader-rfcat-chronosdongle.hex CCBootloader-rfcat-donsdongle.hex CCBootloader-rfcat-ys1.hex
+PROGS = CCBootloader-rfcat-chronosdongle.hex CCBootloader-rfcat-donsdongle.hex CCBootloader-rfcat-ys1.hex
 PCDB = $(PROGS:.hex=.cdb)
 PLNK = $(PROGS:.hex=.lnk)
+PLK = $(PROGS:.hex=.lk)
 PMAP = $(PROGS:.hex=.map)
 PMEM = $(PROGS:.hex=.mem)
 PAOM = $(PROGS:.hex=)
 
-%.c.rel : %.c
-	$(CC) -c $(CFLAGS) -o$*.c.rel $<
+%.c.chronos.rel : %.c
+	$(CC) -c $(CFLAGS) $(CHRONOS_FLAGS) -o$*.c.chronos.rel $<
+
+%.c.dons.rel : %.c
+	$(CC) -c $(CFLAGS) $(DONS_FLAGS) -o$*.c.dons.rel $<
+
+%.c.ys1.rel : %.c
+	$(CC) -c $(CFLAGS) $(YS1_FLAGS) -o$*.c.ys1.rel $<
 
 %.rel : %.asm
 	$(AS) -c $(ASFLAGS) $<
 
 all: $(PROGS)
 
-CCBootloader.hex: $(REL) $(ASM_REL) Makefile
-	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader.hex $(ASM_REL) $(REL)
+CCBootloader-rfcat-chronosdongle.hex: $(CHRONOS_REL) $(ASM_REL)
+	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) $(CHRONOS_FLAGS) -o CCBootloader-rfcat-chronosdongle.hex $(ASM_REL) $(CHRONOS_REL)
 
-CCBootloader-rfcat-chronosdongle.hex: CFLAGS += -DRFCAT -DRFCAT_CHRONOS
-CCBootloader-rfcat-chronosdongle.hex: $(REL) $(ASM_REL) Makefile
-	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader-rfcat-chronosdongle.hex $(ASM_REL) $(REL)
+CCBootloader-rfcat-donsdongle.hex: $(DONS_REL) $(ASM_REL)
+	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) $(DONS_FLAGS) -o CCBootloader-rfcat-donsdongle.hex $(ASM_REL) $(DONS_REL)
 
-CCBootloader-rfcat-donsdongle.hex: CFLAGS += -DRFCAT -DRFCAT_DONSDONGLE
-CCBootloader-rfcat-donsdongle.hex: $(REL) $(ASM_REL) Makefile
-	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader-rfcat-donsdongle.hex $(ASM_REL) $(REL)
-
-CCBootloader-rfcat-ys1.hex: CFLAGS += -DRFCAT -DRFCAT_YARDSTICKONE
-CCBootloader-rfcat-ys1.hex: $(REL) $(ASM_REL) Makefile
-	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) -o CCBootloader-rfcat-ys1.hex $(ASM_REL) $(REL)
+CCBootloader-rfcat-ys1.hex: $(YS1_REL) $(ASM_REL)
+	$(CC) $(LDFLAGS_FLASH) $(CFLAGS) $(YS1_FLAGS) -o CCBootloader-rfcat-ys1.hex $(ASM_REL) $(YS1_REL)
 
 clean:
-	rm -f $(ADB) $(ASM) $(LNK) $(LST) $(REL) $(RST) $(SYM)
+	rm -f src/*.c.*
 	rm -f $(ASM_ADB) $(ASM_LNK) $(ASM_LST) $(ASM_REL) $(ASM_RST) $(ASM_SYM)
-	rm -f $(PROGS) $(PCDB) $(PLNK) $(PMAP) $(PMEM) $(PAOM)
-
-install: CCBootloader.hex
-	goodfet.cc erase
-	goodfet.cc flash CCBootloader.hex
-	goodfet.cc verify CCBootloader.hex
+	rm -f $(PROGS) $(PCDB) $(PLNK) $(PLK) $(PMAP) $(PMEM) $(PAOM)
 
 installchronosdongle: CCBootloader-rfcat-chronosdongle.hex
 	goodfet.cc erase

--- a/src/flash.c
+++ b/src/flash.c
@@ -54,7 +54,7 @@ void flash_erase_page(uint8_t page) {
   //FCTL &=  ~FCTL_ERASE;
 }
 
-void flash_write_trigger() {
+void flash_write_trigger(void) {
   // Enable flash write. Generates a DMA trigger. Must be aligned on a 2-byte
   // boundary and is therefore implemented in assembly.
   
@@ -161,11 +161,11 @@ void flash_check_erase_and_write(uint16_t buff[], uint16_t len, uint16_t flash_a
   flash_write(buff, len, flash_addr);
 }
 
-void flash_reset() {
+void flash_reset(void) {
   erased_page_flags = 0;
 }
 
-void flash_erase_all_user() {
+void flash_erase_all_user(void) {
   // Erase all user flash pages
   uint8_t i;
   for (i=USER_FIRST_PAGE; i<FLASH_PAGES; i++)

--- a/src/flash.h
+++ b/src/flash.h
@@ -38,8 +38,8 @@ void flash_check_and_erase(uint8_t page);
 // Write to flash, erasing pages as needed that have never yet been erased
 void flash_check_erase_and_write(uint16_t buff[], uint16_t len, uint16_t flash_addr);
 // Reset record of which pages have been erased
-void flash_reset();
+void flash_reset(void);
 // Erase all user flash pages
-void flash_erase_all_user();
+void flash_erase_all_user(void);
 
 #endif // _FLASH_H_

--- a/src/hal.c
+++ b/src/hal.c
@@ -20,13 +20,13 @@
 #include "cc1111.h"
 #include "hal.h"
 
-void setup_led() {
+void setup_led(void) {
   // Setup LED and turn it off
   P1DIR |= LED_MASK;
   led_off();
 }
 
-void setup_button() {
+void setup_button(void) {
 #ifdef RFCAT_DONSDONGLE
   P1DIR &= ~4;
 #endif
@@ -39,7 +39,7 @@ void setup_button() {
 }
 
 // any other gpio pins
-void setup_gpio() {
+void setup_gpio(void) {
 #ifdef RFCAT_YARDSTICKONE
   // amplifer configuration pins
   //P0_0 input with pull-up (antenna port power off)
@@ -53,7 +53,7 @@ void setup_gpio() {
 #endif
 }
 
-void led_on() {
+void led_on(void) {
 #ifdef RFCAT_YARDSTICKONE
   LED1 = 1;
   LED2 = 1;
@@ -63,7 +63,7 @@ void led_on() {
 #endif
 }
 
-void led_off() {
+void led_off(void) {
 #ifdef RFCAT_YARDSTICKONE
   LED1 = 0;
   LED2 = 0;
@@ -73,13 +73,13 @@ void led_off() {
 #endif
 }
 
-void usb_up() {
+void usb_up(void) {
   // Bring up the USB link
   P1DIR |= USB_MASK;
   USB_ENABLE = 1;
 }
 
-void usb_down() {
+void usb_down(void) {
   // Bring down the USB link
   USB_ENABLE = 0;
   P1DIR &= ~USB_MASK;

--- a/src/hal.h
+++ b/src/hal.h
@@ -49,14 +49,14 @@
   #define AMP_BYPASS_EN		P2_3
 #endif
 
-void setup_led();
-void led_on();
-void led_off();
-void setup_button();
-void setup_gpio();
+void setup_led(void);
+void led_on(void);
+void led_off(void);
+void setup_button(void);
+void setup_gpio(void);
 
-void usb_up();
-void usb_down();
+void usb_up(void);
+void usb_down(void);
 
 #define BUTTON_PRESSED  	0
 #define GROUNDED		0

--- a/src/main.c
+++ b/src/main.c
@@ -83,15 +83,7 @@ void jump_to_user(void) {
       ljmp #USER_CODE_BASE
     __endasm;
     while (1) {}
-  } else {
-    #ifdef RFCAT
-    return; // need to run bootloader!
-    #else
-    // Oops, no payload. We're stuck now!
-    led_on();
-    while (1) {}
-    #endif
-  }
+  } 
 }
 
 #ifdef TIMER
@@ -177,7 +169,6 @@ uint8_t want_bootloader(void) {
     return 0;
   */
 
-  #ifdef RFCAT 
   // we use the unused I2S SFRs as semaphores.
   // this would be safe even if I2S is in use as they should be reconfigured by 
   // user code 
@@ -185,9 +176,6 @@ uint8_t want_bootloader(void) {
     return 1;
   // no thanks
   return 0;
-  #else
-  return 1;
-  #endif
 }
 
 void bootloader_main (void)
@@ -196,7 +184,6 @@ void bootloader_main (void)
   uint8_t ihx_status;
   uint16_t read_start_addr, read_len;
 
-#ifdef RFCAT
   // use I2S SFR to signal that bootloader is present
   I2SCLKF0= 0xF0;
   I2SCLKF1= 0x0D;
@@ -216,14 +203,10 @@ void bootloader_main (void)
   if (CC1111YSONE_PIN_DC != GROUNDED && !want_bootloader())
   #endif
 
-#else
-  if (!want_bootloader())
-#endif
     jump_to_user();
-#ifdef RFCAT
+
   // reset semaphore 
   I2SCLKF2= 0x00;
-#endif
 
   clock_init();
   

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@
 
 uint8_t bootloader_running = 1;
 
-void clock_init()
+void clock_init(void)
 {
 	// Switch system clock to crystal oscilator
 	CLKCON = (CLKCON & ~CLKCON_OSC_MASK) | (CLKCON_OSC_XTAL);
@@ -59,14 +59,14 @@ void delay (unsigned char n) {
 			  nop();
 }
 
-uint8_t check_for_payload() {
+uint8_t check_for_payload(void) {
   if (*((__xdata uint8_t*)USER_CODE_BASE) == 0xFF)
     return 0;
   else
     return 1;
 }
 
-void jump_to_user() {
+void jump_to_user(void) {
   // Disable all interrupts
   EA = 0;
   IEN0 = IEN1 = IEN2 = 0;
@@ -95,7 +95,7 @@ void jump_to_user() {
 }
 
 #ifdef TIMER
-void setup_timer1() {
+void setup_timer1(void) {
   // Clear Timer 1 channel 1 and overflow interrupt flag
   // CPU interrupt flag (IRCON) for Timer 1 is cleared automatically by hardware.
   T1CTL &= ~T1CTL_OVFIF;
@@ -112,14 +112,14 @@ void setup_timer1() {
 #endif
 
 #ifdef TIMER
-void disable_timer1() {
+void disable_timer1(oid) {
   // Disable Timer 1 interrupt
   IEN1 &= ~IEN1_T1IE;
 }
 #endif
 
 #ifdef TIMER
-void timer1_isr() __naked {
+void timer1_isr(void) __naked {
   T1CTL &= ~T1CTL_OVFIF;
   
   // We need to issue a RETI instruction to
@@ -145,7 +145,7 @@ void timer1_isr() __naked {
 }
 #endif
 
-void timer1_isr_forward() __naked {
+void timer1_isr_forward(void) __naked {
   #ifdef TIMER
   __asm
   	push acc
@@ -165,7 +165,7 @@ void timer1_isr_forward() __naked {
   #endif
 }
 
-uint8_t want_bootloader() {
+uint8_t want_bootloader(void) {
   // Check if we want to the bootloader to run
   // Here is the place to check for things like USB power and jump straight to
   // user code under some conditions.
@@ -190,7 +190,7 @@ uint8_t want_bootloader() {
   #endif
 }
 
-void bootloader_main ()
+void bootloader_main (void)
 {
   __xdata char buff[100];
   uint8_t ihx_status;

--- a/src/usb.h
+++ b/src/usb.h
@@ -25,12 +25,12 @@
 
 // External interface
 
-void usb_init();
-void usb_disable();
-void usb_enable();
-char usb_getchar();
+void usb_init(void);
+void usb_disable(void);
+void usb_enable(void);
+char usb_getchar(void);
 void usb_putchar(char c);
-void usb_flush();
+void usb_flush(void);
 
 void usb_putstr(char* buff);
 void usb_readline(char* buff);
@@ -38,7 +38,7 @@ void usb_readline(char* buff);
 // End external interface
 
 // USB interrupt handler
-void usb_isr() __interrupt 6;
+void usb_isr(void) __interrupt (6);
 
 #define USB_SETUP_DIR_MASK    (0x01 << 7)
 #define USB_SETUP_TYPE_MASK   (0x03 << 5)


### PR DESCRIPTION
Changes for newer SDCC
Reduced warnings
allow real building of all targets with just calling "make" (defines are now honored properly)